### PR TITLE
Add error message: Github API rate limit exceeded

### DIFF
--- a/lib/util.lua
+++ b/lib/util.lua
@@ -87,6 +87,15 @@ function util:getInfo()
             error("Failed to get information: " .. err)
         end
         if resp.status_code ~= 200 then
+            if resp.headers["X-Ratelimit-Reset"] and resp.headers["X-Ratelimit-Remaining"] == "0" then
+                local wait_seconds = resp.headers["X-Ratelimit-Reset"] - os.time()
+                local minutes = math.floor(wait_seconds / 60)
+                local seconds = math.floor(wait_seconds % 60)
+                local time = (minutes > 0) and (minutes .. " minutes") or (seconds .. " seconds")
+                local body = json.decode(resp.body)
+                print("📢 [Github] " .. body.message .. " " .. body.documentation_url)
+                print("📢 Please try again in " .. time)
+            end
             error("Failed to get information: status_code =>" .. resp.status_code)
         end
 


### PR DESCRIPTION
```
https://api.github.com/repos/oven-sh/bun/releases
{"message":"API rate limit exceeded for ***. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
```
```
> vfox install bun@1.2.18
📢 [Github] API rate limit exceeded for 47.86.161.241. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting
📢 Please try again in 43 minutes
plugin [PreInstall] method error: C:\Users\tiany\.version-fox\plugin\bun\lib\util.lua:130: Failed to get information: status_code =>403
```